### PR TITLE
Add menu icon for SelectiveStarMask script

### DIFF
--- a/SelectiveStarMask/SelectiveStarMask-icon.svg
+++ b/SelectiveStarMask/SelectiveStarMask-icon.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="bgGradient" x1="14" y1="6" x2="50" y2="58" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#141d3d"/>
+      <stop offset="1" stop-color="#0b0f1f"/>
+    </linearGradient>
+    <radialGradient id="maskGlow" cx="32" cy="32" r="26" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#4ea6ff" stop-opacity="0.9"/>
+      <stop offset="1" stop-color="#1c3d6b" stop-opacity="0.4"/>
+    </radialGradient>
+    <radialGradient id="starCore" cx="32" cy="26" r="10" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff5ce"/>
+      <stop offset="0.65" stop-color="#ffd95f"/>
+      <stop offset="1" stop-color="#ffae00"/>
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" ry="12" fill="url(#bgGradient)"/>
+  <g opacity="0.6">
+    <circle cx="20" cy="20" r="2" fill="#7fb3ff"/>
+    <circle cx="48" cy="18" r="1.6" fill="#9bd1ff"/>
+    <circle cx="14" cy="36" r="1.4" fill="#5f8fe0"/>
+    <circle cx="50" cy="40" r="1.8" fill="#87b9ff"/>
+    <circle cx="28" cy="50" r="1.2" fill="#698dd1"/>
+  </g>
+  <circle cx="32" cy="32" r="22" fill="url(#maskGlow)" stroke="#7bc4ff" stroke-width="2"/>
+  <circle cx="32" cy="32" r="14" fill="none" stroke="#d5ecff" stroke-width="1.6" stroke-dasharray="4.5 3"/>
+  <path d="M32 16l3.2 7.8 8.4 0.7-6.4 5.7 1.9 8.3L32 33.4l-7.1 4.1 1.9-8.3-6.4-5.7 8.4-0.7z" fill="url(#starCore)" stroke="#ffe9a3" stroke-width="1.2" stroke-linejoin="round"/>
+  <path d="M32 34c-6.4 0-12 5.1-12 11.8 0 1.2 0.2 2.3 0.4 3.4 0.2 0.7 0.9 1.1 1.6 1l20-3.1c0.7-0.1 1.2-0.6 1.3-1.3 0.2-1.1 0.3-2.1 0.3-3.1 0-6.7-5.2-8.7-11.6-8.7z" fill="#17284d" opacity="0.75"/>
+  <path d="M21.2 48.4l-5.6 5.6" stroke="#79aaff" stroke-width="2.2" stroke-linecap="round"/>
+  <path d="M42.8 48.4l5.6 5.6" stroke="#79aaff" stroke-width="2.2" stroke-linecap="round"/>
+</svg>

--- a/SelectiveStarMask/SelectiveStarMask-main.js
+++ b/SelectiveStarMask/SelectiveStarMask-main.js
@@ -21,6 +21,7 @@
     using StarDetector and PSF fitting. <br/>\
     <br/>\
     Copyright &copy; 2024-2025 Boris Emchenko (astromania.info)
+#feature-icon SelectiveStarMask-icon.svg
 
 //File id
 #define __SELECTIVESTARMASK_MAIN__


### PR DESCRIPTION
## Summary
- add a dedicated SelectiveStarMask icon with a circular mask and star motif
- reference the SVG icon from the script so it appears in PixInsight's menu

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb928d3b808325a9e3bd85d98a3b84