### PR TITLE
Add adjustable mask size parameter to SelectiveStarMask

### DIFF
--- a/SelectiveStarMask/SelectiveStarMask-GUI.js
+++ b/SelectiveStarMask/SelectiveStarMask-GUI.js
@@ -34,6 +34,7 @@
 #include <pjsr/SectionBar.jsh>
 #include <pjsr/FontFamily.jsh>
 #include <pjsr/Color.jsh>
+#include <pjsr/NumericControl.jsh>
 
 /*
  * dialog
@@ -302,10 +303,41 @@ function SelectiveStarMask_Dialog(refView) {
     }
 
 
+    // -- Script parameters --
+
+    this.adjustMaskSize_Control = new NumericControl(this);
+    with (this.adjustMaskSize_Control) {
+        label.text = "Adjust mask size:";
+        label.minWidth = labelWidth1;
+        label.textAlignment = TextAlign_Right | TextAlign_VertCenter;
+        setRange(0.1, 5);
+        slider.setRange(0, 490);
+        slider.scaledMinWidth = 200;
+        setPrecision(2);
+        setValue(Config.AdjFact != undefined ? Config.AdjFact : 0.5);
+        toolTip = "<p>Star size adjustment factor from 0.1 to 5, default 0.5.</p>";
+        onValueUpdated = function (value) {
+            Config.AdjFact = value;
+            if (Engine)
+                Engine.AdjFact = value;
+        };
+    }
+
+    this.ScriptParametersGroupBox = new GroupBox(this);
+    with (this.ScriptParametersGroupBox) {
+        title = "Script paramets";
+        sizer = new VerticalSizer;
+        sizer.margin = 6;
+        sizer.spacing = 4;
+        sizer.add(this.adjustMaskSize_Control);
+        setScaledMinWidth( MIN_DIALOG_WIDTH );
+    }
+
+
     // -- Filter ---
 
 
-	// -- Size filter --
+       // -- Size filter --
     // Min size filter
     this.minSizeFilter_Label = new Label(this);
     with (this.minSizeFilter_Label) {
@@ -907,7 +939,10 @@ function SelectiveStarMask_Dialog(refView) {
         spacing = 6;
         add(this.helpLabel);
         addSpacing(4);
-		  add(this.InformationGroupBox);
+        add(this.InformationGroupBox);
+        addSpacing(4);
+
+        add(this.ScriptParametersGroupBox);
         addSpacing(4);
 
         add(this.Filter_Sizer);

--- a/SelectiveStarMask/SelectiveStarMask-main.js
+++ b/SelectiveStarMask/SelectiveStarMask-main.js
@@ -74,11 +74,13 @@ function main() {
 
     Engine = new SelectiveStarMask_engine();
     Engine.debug = __DEBUGF__;
+    Engine.AdjFact = Config.AdjFact;
 
     if (Parameters.isGlobalTarget || Parameters.isViewTarget) {
         if (__DEBUGF__)
             console.noteln("Running from saved script instance");
         Config.importParameters();
+        Engine.AdjFact = Config.AdjFact;
 
         // Run without GUI
         if (Parameters.isViewTarget) {

--- a/SelectiveStarMask/SelectiveStarMask-settings.js
+++ b/SelectiveStarMask/SelectiveStarMask-settings.js
@@ -29,6 +29,8 @@ function ConfigData() {
     if (__DEBUGF__)
         console.writeln('<br/><br/>Config object created...<br/>');
 
+    this.AdjFact = 0.5;
+
     //Helper functions
     function load(key, type, default_value, precision = 2) {
         let retV = Settings.read(__SETTINGS_KEY_BASE__ + key, type);
@@ -69,6 +71,9 @@ function ConfigData() {
         if ((o = load("FilterFlux_max", DataType_Float, MAX_INT, 3)) != null)
             this.FilterFlux_max = o;
 
+        if ((o = load("AdjFact", DataType_Float, 0.5, 2)) != null)
+            this.AdjFact = o;
+
         
         /*
         if ((o = load("InputPath", DataType_String)) != null)
@@ -95,6 +100,7 @@ function ConfigData() {
         save("FilterSize_max", DataType_Float, this.FilterSize_max);
         save("FilterFlux_min", DataType_Float, this.FilterFlux_min);
         save("FilterFlux_max", DataType_Float, this.FilterFlux_max);
+        save("AdjFact", DataType_Float, this.AdjFact);
 
         /* =
         save("NeedCalibration", DataType_Boolean, this.NeedCalibration);
@@ -122,6 +128,7 @@ function ConfigData() {
         Parameters.set("FilterSize_max",        this.FilterSize_max);
         Parameters.set("FilterFlux_min",        this.FilterFlux_min);
         Parameters.set("FilterFlux_max",        this.FilterFlux_max);
+        Parameters.set("AdjFact",               this.AdjFact);
 
         /*
         Parameters.set("NeedCalibration", 			this.NeedCalibration);
@@ -151,6 +158,8 @@ function ConfigData() {
             this.FilterFlux_min = Parameters.getReal("FilterFlux_min");
         if (Parameters.has("FilterFlux_max"))
             this.FilterFlux_max = Parameters.getReal("FilterFlux_max");
+        if (Parameters.has("AdjFact"))
+            this.AdjFact = Parameters.getReal("AdjFact");
 
         /*
         if (Parameters.has("NeedCalibration"))
@@ -179,6 +188,7 @@ function ConfigData() {
         console.writeln("FilterSize_max:                 " + this.FilterSize_max);
         console.writeln("FilterFlux_min:                 " + this.FilterFlux_min);
         console.writeln("FilterFlux_max:                 " + this.FilterFlux_max);
+        console.writeln("AdjFact:                        " + this.AdjFact);
 
         /*
         console.writeln("InputPath:                      " + this.InputPath);


### PR DESCRIPTION
## Summary
- add a "Script paramets" group with a numeric control for mask size adjustment in the SelectiveStarMask dialog
- persist the adjustment factor across sessions and script instances through the configuration object
- initialize the processing engine with the configured adjustment factor so mask generation honors the UI value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc02ef34588325b3f61aedc827c0eb