### PR TITLE
Add contour inner size adjustment control

### DIFF
--- a/SelectiveStarMask/SelectiveStarMask-GUI.js
+++ b/SelectiveStarMask/SelectiveStarMask-GUI.js
@@ -550,9 +550,11 @@ function SelectiveStarMask_Dialog(refView) {
         text = "Countour mask";
         checked = Config.contourMask;
         toolTip = "<p>Create mask as a countour.</p>";
-		  setScaledMinWidth(MIN_DIALOG_WIDTH / 6 - 6);
+                  setScaledMinWidth(MIN_DIALOG_WIDTH / 6 - 6);
         onClick = function (checked) {
             Config.contourMask = checked;
+            if (this.dialog.adjustInnerSize_Control)
+                this.dialog.adjustInnerSize_Control.enabled = checked;
         };
     };
     this.Parameters_Sizer = new HorizontalSizer;
@@ -583,6 +585,24 @@ function SelectiveStarMask_Dialog(refView) {
         };
     }
 
+    this.adjustInnerSize_Control = new NumericControl(this);
+    with (this.adjustInnerSize_Control) {
+        label.text = "Adjust inner size:";
+        label.textAlignment = TextAlign_Right | TextAlign_VertCenter;
+        setRange(0.01, 5);
+        slider.setRange(0, 499);
+        slider.scaledMinWidth = 200;
+        setPrecision(2);
+        setValue(Config.AdjFactor_countor != undefined ? Config.AdjFactor_countor : 0.5);
+        enabled = Config.contourMask;
+        toolTip = "<p>Inner star size adjustment factor from 0.01 to 5, default 0.5.</p>";
+        onValueUpdated = function (value) {
+            Config.AdjFactor_countor = value;
+            if (Engine)
+                Engine.AdjFactor_countor = value;
+        };
+    }
+
     // Mask Parameters groupbox
     this.MaskParametersGroupBox = new GroupBox(this);
     with (this.MaskParametersGroupBox) {
@@ -592,6 +612,7 @@ function SelectiveStarMask_Dialog(refView) {
         sizer.spacing = 4;
         sizer.add(this.Parameters_Sizer);
         sizer.add(this.adjustMaskSize_Control);
+        sizer.add(this.adjustInnerSize_Control);
         setScaledMinWidth( MIN_DIALOG_WIDTH / 3 + this.logicalPixelsToPhysical(100) );
     }
 
@@ -1133,11 +1154,15 @@ function mainGUI() {
    if (refView.window.filePath) console.writeln ("ImagePath: " + refView.window.filePath + "");
 
    Config.loadSettings();
+   Engine.AdjFact = Config.AdjFact;
+   Engine.AdjFactor_countor = Config.AdjFactor_countor;
 
    if (Parameters.isGlobalTarget || Parameters.isViewTarget) {
         if (__DEBUGF__)
             console.writeln("Running script instance");
         Config.importParameters();
+        Engine.AdjFact = Config.AdjFact;
+        Engine.AdjFactor_countor = Config.AdjFactor_countor;
 
    } else {
         if (__DEBUGF__)

--- a/SelectiveStarMask/SelectiveStarMask-main.js
+++ b/SelectiveStarMask/SelectiveStarMask-main.js
@@ -75,12 +75,14 @@ function main() {
     Engine = new SelectiveStarMask_engine();
     Engine.debug = __DEBUGF__;
     Engine.AdjFact = Config.AdjFact;
+    Engine.AdjFactor_countor = Config.AdjFactor_countor;
 
     if (Parameters.isGlobalTarget || Parameters.isViewTarget) {
         if (__DEBUGF__)
             console.noteln("Running from saved script instance");
         Config.importParameters();
         Engine.AdjFact = Config.AdjFact;
+        Engine.AdjFactor_countor = Config.AdjFactor_countor;
 
         // Run without GUI
         if (Parameters.isViewTarget) {

--- a/SelectiveStarMask/SelectiveStarMask-settings.js
+++ b/SelectiveStarMask/SelectiveStarMask-settings.js
@@ -30,6 +30,7 @@ function ConfigData() {
         console.writeln('<br/><br/>Config object created...<br/>');
 
     this.AdjFact = 0.5;
+    this.AdjFactor_countor = 0.5;
 
     //Helper functions
     function load(key, type, default_value, precision = 2) {
@@ -73,6 +74,8 @@ function ConfigData() {
 
         if ((o = load("AdjFact", DataType_Float, 0.5, 2)) != null)
             this.AdjFact = o;
+        if ((o = load("AdjFactor_countor", DataType_Float, 0.5, 2)) != null)
+            this.AdjFactor_countor = o;
 
         
         /*
@@ -101,6 +104,7 @@ function ConfigData() {
         save("FilterFlux_min", DataType_Float, this.FilterFlux_min);
         save("FilterFlux_max", DataType_Float, this.FilterFlux_max);
         save("AdjFact", DataType_Float, this.AdjFact);
+        save("AdjFactor_countor", DataType_Float, this.AdjFactor_countor);
 
         /* =
         save("NeedCalibration", DataType_Boolean, this.NeedCalibration);
@@ -129,6 +133,7 @@ function ConfigData() {
         Parameters.set("FilterFlux_min",        this.FilterFlux_min);
         Parameters.set("FilterFlux_max",        this.FilterFlux_max);
         Parameters.set("AdjFact",               this.AdjFact);
+        Parameters.set("AdjFactor_countor",     this.AdjFactor_countor);
 
         /*
         Parameters.set("NeedCalibration", 			this.NeedCalibration);
@@ -160,6 +165,8 @@ function ConfigData() {
             this.FilterFlux_max = Parameters.getReal("FilterFlux_max");
         if (Parameters.has("AdjFact"))
             this.AdjFact = Parameters.getReal("AdjFact");
+        if (Parameters.has("AdjFactor_countor"))
+            this.AdjFactor_countor = Parameters.getReal("AdjFactor_countor");
 
         /*
         if (Parameters.has("NeedCalibration"))
@@ -189,6 +196,7 @@ function ConfigData() {
         console.writeln("FilterFlux_min:                 " + this.FilterFlux_min);
         console.writeln("FilterFlux_max:                 " + this.FilterFlux_max);
         console.writeln("AdjFact:                        " + this.AdjFact);
+        console.writeln("AdjFactor_countor:              " + this.AdjFactor_countor);
 
         /*
         console.writeln("InputPath:                      " + this.InputPath);


### PR DESCRIPTION
## Summary
- add an inner contour size NumericControl tied to the engine contour adjustment factor
- enable the new control only when contour masks are active
- persist the new adjustment factor through settings, parameter export, and CLI execution

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc0c70dd648325a9b96d73403266eb